### PR TITLE
Add support for harness basic auth

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -260,15 +260,17 @@ func (svr *Service) login() (conn net.Conn, cm *ConnectionManager, err error) {
 	}
 
 	loginMsg := &msg.Login{
-		Arch:      runtime.GOARCH,
-		Os:        runtime.GOOS,
-		PoolCount: svr.cfg.Transport.PoolCount,
-		User:      svr.cfg.User,
-		Version:   version.Full(),
-		Timestamp: time.Now().Unix(),
-		RunID:     svr.runID,
-		Metas:     svr.cfg.Metadatas,
-		ApiKey:    svr.cfg.ApiKey,
+		Arch:            runtime.GOARCH,
+		Os:              runtime.GOOS,
+		PoolCount:       svr.cfg.Transport.PoolCount,
+		User:            svr.cfg.User,
+		Version:         version.Full(),
+		Timestamp:       time.Now().Unix(),
+		RunID:           svr.runID,
+		Metas:           svr.cfg.Metadatas,
+		ApiKey:          svr.cfg.ApiKey,
+		HarnessUsername: svr.cfg.HarnessUsername,
+		HarnessPassword: svr.cfg.HarnessPassword,
 	}
 
 	// Add auth

--- a/pkg/config/legacy/client.go
+++ b/pkg/config/legacy/client.go
@@ -168,7 +168,9 @@ type ClientCommonConf struct {
 	// Admin port must be set first.
 	PprofEnable bool `ini:"pprof_enable" json:"pprof_enable"`
 
-	ApiKey string `ini:"api_key" json:"api_key"`
+	ApiKey          string `ini:"api_key" json:"api_key"`
+	HarnessUsername string `ini:"harness_username" json:"harness_username"`
+	HarnessPassword string `ini:"harness_password" json:"harness_password"`
 }
 
 // Supported sources including: string(file path), []byte, Reader interface.

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -188,7 +188,7 @@ func LoadClientConfig(path string) (
 		}
 		cliCfg = legacy.Convert_ClientCommonConf_To_v1(&legacyCommon)
 		for _, c := range legacyPxyCfgs {
-			pxyCfgs = append(pxyCfgs, legacy.Convert_ProxyConf_To_v1(c))
+			pxyCfgs = append(pxyCfgs, legacy.Convert_ProxyConf_To_v1(c, cliCfg.HarnessUsername, cliCfg.HarnessPassword))
 		}
 		for _, c := range legacyVisitorCfgs {
 			visitorCfgs = append(visitorCfgs, legacy.Convert_VisitorConf_To_v1(c))

--- a/pkg/config/v1/client.go
+++ b/pkg/config/v1/client.go
@@ -71,7 +71,9 @@ type ClientCommonConfig struct {
 	// Include other config files for proxies.
 	IncludeConfigFiles []string `json:"includes,omitempty"`
 
-	ApiKey string `json:"api_key,omitempty"`
+	ApiKey          string `json:"api_key,omitempty"`
+	HarnessUsername string `json:"harness_username"`
+	HarnessPassword string `json:"harness_password"`
 }
 
 func (c *ClientCommonConfig) Complete() {

--- a/pkg/msg/msg.go
+++ b/pkg/msg/msg.go
@@ -65,16 +65,18 @@ var TypeNameNatHoleResp = reflect.TypeOf(&NatHoleResp{}).Elem().Name()
 
 // When frpc start, client send this message to login to server.
 type Login struct {
-	Version      string            `json:"version,omitempty"`
-	Hostname     string            `json:"hostname,omitempty"`
-	Os           string            `json:"os,omitempty"`
-	Arch         string            `json:"arch,omitempty"`
-	User         string            `json:"user,omitempty"`
-	PrivilegeKey string            `json:"privilege_key,omitempty"`
-	Timestamp    int64             `json:"timestamp,omitempty"`
-	RunID        string            `json:"run_id,omitempty"`
-	Metas        map[string]string `json:"metas,omitempty"`
-	ApiKey       string            `json:"api_key,omitempty"`
+	Version         string            `json:"version,omitempty"`
+	Hostname        string            `json:"hostname,omitempty"`
+	Os              string            `json:"os,omitempty"`
+	Arch            string            `json:"arch,omitempty"`
+	User            string            `json:"user,omitempty"`
+	PrivilegeKey    string            `json:"privilege_key,omitempty"`
+	Timestamp       int64             `json:"timestamp,omitempty"`
+	RunID           string            `json:"run_id,omitempty"`
+	Metas           map[string]string `json:"metas,omitempty"`
+	ApiKey          string            `json:"api_key,omitempty"`
+	HarnessUsername string            `json:"harness_username,omitempty"`
+	HarnessPassword string            `json:"harness_password,omitempty"`
 
 	// Some global configures.
 	PoolCount int `json:"pool_count,omitempty"`

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -205,7 +205,8 @@ func (pxy *BaseProxy) startCommonTCPListenersHandler() {
 						continue
 					}
 
-					registerClient(pxy.loginMsg.ApiKey, 0, pxy.serverCfg.HarnessEndpoint, true)
+					registerClient(pxy.loginMsg.ApiKey, 0, pxy.serverCfg.HarnessEndpoint, true,
+						pxy.loginMsg.HarnessUsername, pxy.loginMsg.HarnessPassword)
 					xl.Warn("listener is closed: %s", err)
 					return
 				}

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -163,7 +163,7 @@ func registerClient(apiKey string, port int, endpoints string, shouldDelete bool
 
 		resp, err := client.Do(req)
 		if err != nil {
-			fmt.Printf("Error in validating API key %v", err.Error())
+			fmt.Printf("Error in validating API key %s\n", err.Error())
 			continue
 		}
 		defer resp.Body.Close()

--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -158,14 +158,11 @@ func registerClient(apiKey string, port int, endpoints string, shouldDelete bool
 			fmt.Println(err)
 			continue
 		}
-		fmt.Println(req)
 		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("x-api-key", apiKey)
 
 		resp, err := client.Do(req)
-		//fmt.Println(resp, err)
 		if err != nil {
-			fmt.Println(resp)
 			fmt.Printf("Error in validating API key %v", err.Error())
 			continue
 		}


### PR DESCRIPTION
Sample `frpc.ini`:

`[common]`
`server_addr=localhost`
`log_level = debug`
`api_key=pat.kmpySmUISimoRrJL6NL73w.some.apikey`
`harness_username = huser`
`harness_password = hpass`

Harness username and password is used to authenticate the proxy requests. If these values are not set, we hash the API Key and use the hashstring as both username and password.
