### PR TITLE
Feat/secure connect review

### DIFF
--- a/dockerfiles/frpc.ini.docker
+++ b/dockerfiles/frpc.ini.docker
@@ -2,6 +2,8 @@
 server_addr = ${REMOTE_SERVER}
 log_level = debug
 api_key = ${API_KEY}
+harness_username = ${USER_NAME}
+harness_password = ${USER_PASSWORD}
 [plugin_proxy-${REMOTE_PORT}]
 type = tcp
 remote_port = ${REMOTE_PORT}

--- a/pkg/config/legacy/conversion.go
+++ b/pkg/config/legacy/conversion.go
@@ -15,7 +15,7 @@
 package legacy
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"strings"
 
@@ -32,7 +32,7 @@ func Convert_ClientCommonConf_To_v1(conf *ClientCommonConf) *v1.ClientCommonConf
 		out.HarnessUsername = conf.HarnessUsername
 		out.HarnessPassword = conf.HarnessPassword
 	} else {
-		hasher := md5.New()
+		hasher := sha256.New()
 		hasher.Write([]byte(conf.ApiKey))
 		hashBytes := hasher.Sum(nil)
 		hashString := hex.EncodeToString(hashBytes)


### PR DESCRIPTION
### Summary

1. added SHA256 hash instead of MD5 
2. Ability to provide user name and password for frpc client 


Testing 
<img width="1544" alt="Screenshot 2024-10-15 at 20 07 10" src="https://github.com/user-attachments/assets/00fc00c7-c456-4a6f-9f69-e3f3ad8f6c41">
<img width="1728" alt="Screenshot 2024-10-15 at 20 07 18" src="https://github.com/user-attachments/assets/66c129da-5df4-4ced-9b1e-1cd77b5898fe">

<img width="1394" alt="Screenshot 2024-10-15 at 20 09 32" src="https://github.com/user-attachments/assets/6f5e9747-7b4b-4a3d-b32b-fba93ad39dd9">
<img width="1518" alt="Screenshot 2024-10-15 at 20 09 43" src="https://github.com/user-attachments/assets/95f27797-a1eb-4697-b8a8-45a98b90a414">


